### PR TITLE
Vendigo 투척물 정상화

### DIFF
--- a/Assets/2.Scripts/Game/Enemy/Vendigo/Ranged attack/Projectile.cs
+++ b/Assets/2.Scripts/Game/Enemy/Vendigo/Ranged attack/Projectile.cs
@@ -61,9 +61,14 @@ public class Projectile : MonoBehaviour
         // “Player” 태그를 가진 객체와 부딪히면
         if (collision.gameObject.CompareTag("Player"))
         {
-            var hp = collision.gameObject.GetComponent<PlayerStatus>();
+            var hp = collision.gameObject.GetComponentInParent<PlayerStatus>();
             if (hp != null) hp.TakeDamage(damage);
         }
-       
+        
+        if (collision.gameObject.CompareTag("Player"))
+        {
+            var hp = collision.gameObject.GetComponentInParent<PlayerStatusProxy>();
+            if (hp != null) hp.TakeDamage(damage);
+        }
     }
 }


### PR DESCRIPTION
- 기존의 Projectile 스크립트 수정
- 플레이어가 Vendigo의 투척물에 맞아도 체력이 닳지 않았던 문제를 해결